### PR TITLE
Allow switch widgets to display "key: value" instead of the default "key"

### DIFF
--- a/src/browser/js/app/widgets/buttons/switch.js
+++ b/src/browser/js/app/widgets/buttons/switch.js
@@ -27,6 +27,7 @@ module.exports = class Switch extends _widgets_base {
             _switch:'switch',
 
             horizontal:false,
+            show_values:false,
             values:{"Value 1":1,"Value 2":2},
             value:'',
 
@@ -52,7 +53,8 @@ module.exports = class Switch extends _widgets_base {
 
         for (var k in this.getProp('values')) {
             this.values.push(this.getProp('values')[k])
-            $(`<div class="value">${iconify(parseFloat(k) != k ? k : this.getProp("values")[k])}</div>`).data({value:this.getProp('values')[k]}).appendTo(this.widget)
+            var the_val = (this.getProp('show_values')) ? ': ' + this.getProp('values')[k] : ''
+            $(`<div class="value">${iconify(parseFloat(k) != k ? k : this.getProp("values")[k]) + the_val}</div>`).data({value:this.getProp('values')[k]}).appendTo(this.widget)
         }
 
         this.value = undefined


### PR DESCRIPTION
These are my first nodejs lines of code, so feel free to reject or modify this PR