### PR TITLE
Disable hardware acceleration in Electron app

### DIFF
--- a/app/main/electron-app.js
+++ b/app/main/electron-app.js
@@ -3,7 +3,7 @@ var {app, Menu} = require('electron'),
     path = require('path')
 
 app.commandLine.appendSwitch('--touch-events')
-
+app.disableHardwareAcceleration();
 
 if (settings.read('noVsync') || (!settings.cli && settings.read('argv')['disable-vsync'])) {
     app.commandLine.appendSwitch('--disable-gpu-vsync')


### PR DESCRIPTION
This fixes #132 on my system as suggested by c0b41/Manta@09c1bb7046b9ac5e0d88a8568ff0b33407a29e41.

Reading Electron's [Offscreen rendering](https://github.com/electron/electron/blob/master/docs/tutorial/offscreen-rendering.md) documentation, I wonder if Open Stage Control would benefit at all from hardware acceleration. Depending on the answer to this question, it could make sense to add another command line switch.. to re-enable the hardware acceleration.