### PR TITLE
MIDI problem with multifaders - workaround in midi.py (#247)

### DIFF
--- a/app/main/midi.py
+++ b/app/main/midi.py
@@ -172,9 +172,14 @@ def sendMidi(name, event, *args):
         else:
             m = rtmidi.MidiMessage.noteOff(args[0], args[1])
 
-    elif 'control' in event and len(args) == 3:
+    elif 'control' in event:
         args = [int(round(x)) for x in args]
-        m = rtmidi.MidiMessage.controllerEvent(*args)
+        if len(args) == 3:
+            m = rtmidi.MidiMessage.controllerEvent(*args)
+        elif len(args) == 4:
+            ipcSend('log', 'salut')
+            # multifader
+            m = rtmidi.MidiMessage.controllerEvent(args[0], args[1] + args[2], args[3])
 
     elif 'program' in event and len(args) == 2:
         args = [int(round(x)) for x in args]


### PR DESCRIPTION
Workaround to MIDI problem with multifaders (#247)

As I said in issue, this is not meant to be the cleanest code possible, but only a quick workaround.