### PR TITLE
Upgrade osc.js to v2.2.1

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -25,7 +25,7 @@
     "chokidar": "2.0.3",
     "electron-localshortcut": "3.1.0",
     "express": "4.16.3",
-    "osc": "2.2.0",
+    "osc": "2.2.1",
     "python-shell": "0.5.0",
     "rtsp-ffmpeg": "0.0.12",
     "vmodule": "1.0.1",


### PR DESCRIPTION
This in turn upgrades the serialport dependency to v6.x which fixes potential build problems (cf. colinbdclark/osc.js#106).