### PR TITLE
add osx backspace shortcut for deleting widgets

### DIFF
--- a/src/browser/js/app/editor/index.js
+++ b/src/browser/js/app/editor/index.js
@@ -88,7 +88,7 @@ var Editor = class Editor {
                 if (e.target.classList.contains('no-keybinding')) return
                 this.pasteWidget(this.mousePosition.x, this.mousePosition.y, true)
             })
-            keyboardJS.bind('delete', (e)=>{
+            keyboardJS.bind(['delete','backspace'], (e)=>{
                 if (e.target.classList.contains('no-keybinding')) return
                 this.deleteWidget()
             })


### PR DESCRIPTION
on osx , the 'delete' key is named backspace in keyboardJS

tested on my machine 