### PR TITLE
WIP : add mod + e to toggle editor

### DIFF
--- a/src/browser/js/app/editor/index.js
+++ b/src/browser/js/app/editor/index.js
@@ -135,6 +135,12 @@ var Editor = class Editor {
             sessionManager.save()
         })
 
+        keyboardJS.bind('mod + e', (e)=>{
+            e.preventDefault()
+            if(EDITING){editor.disable()}
+            else{editor.enable()}
+        })
+
 
     }
 


### PR DESCRIPTION
just another lazy shortcut to toggle edition mode (mod + e) :

not sure which way editor.enable() / .disable() should be called from the keyboardJS callback: 

both this.enable(), and editor.enable() seems to work here, though some variables may be not visible inside the callback.

although , if merged, we need to add appropriate documentation

