### PR TITLE
WIP  : editor traversing shortcuts

### DIFF
--- a/src/browser/js/app/editor/index.js
+++ b/src/browser/js/app/editor/index.js
@@ -129,11 +129,11 @@ var Editor = class Editor {
                     toSelect = curWidget.parent
                 }
                 else if(e.key == 'ArrowDown' ){
-                    const widgetList =  curWidget.getProp('widgets')
-                    if(widgetList && widgetList.length){
+                    const objectWidgetList =  curWidget.getProp('widgets')
+                    if(objectWidgetList && objectWidgetList.length){
                         // multiple objects can have the same id, need to check we're getting the child one
-                        const toSelectList = widgetManager.getWidgetById(widgetList[0].id)
-                        .filter(el=>el.hash!=curWidget.hash && el.parent===curWidget)
+                        const toSelectList = widgetManager.getWidgetById(objectWidgetList[0].id)
+                        .filter(el=> el.parent===curWidget)
                         if(toSelectList){
                             toSelectList.sort((a,b)=>a.container.offsetLeft>b.container.offsetLeft)
                             toSelect = toSelectList[0]

--- a/src/browser/js/app/editor/index.js
+++ b/src/browser/js/app/editor/index.js
@@ -129,43 +129,27 @@ var Editor = class Editor {
                     toSelect = curWidget.parent
                 }
                 else if(e.key == 'ArrowDown' ){
-                    const objectWidgetList =  curWidget.getProp('widgets')
-                    if(objectWidgetList && objectWidgetList.length){
+                    const toSelectList =  curWidget.childrenHashes
+                    .map(h=>widgetManager.widgets[h])
+                    .filter(w=>w.parent==curWidget)
+                    
+                    if(toSelectList && toSelectList.length){
                         // multiple objects can have the same id, need to check we're getting the child one
-                        const toSelectList = widgetManager.getWidgetById(objectWidgetList[0].id)
-                        .filter(el=> el.parent===curWidget)
-                        if(toSelectList){
                             toSelectList.sort((a,b)=>a.container.offsetLeft>b.container.offsetLeft)
                             toSelect = toSelectList[0]
-                        }
-
                     }
 
                 }
                 else if((e.key == 'ArrowLeft') || (e.key == 'ArrowRight')){
-                    const objectWidgetList = curWidget.parent.getProp('widgets')
-                    if(objectWidgetList && objectWidgetList.length){
-                        // multiple objects can have the same id, need to check we're getting the right one
-                        // would be cleaner if widgets returned by getProp('widgets') had the hash inside...
-                        const equal_fields = ['id','left','top','width','height']
-                        const widgetList = objectWidgetList.map(objectW=>{
-                            const widgetsWithSameIds = widgetManager.getWidgetById(objectW.id)
-                            .filter(el=>el.parent===curWidget.parent)
-                            return widgetsWithSameIds.find(otherW=>
-                                {
-                                    for (const el of equal_fields){
-                                        if(otherW.cachedProps[el]!==objectW[el]){
-                                            return false
-                                        }
-                                    }
-                                    return true
-                                })
-                            })
-                        widgetList.sort((a,b)=>a.container.offsetLeft>b.container.offsetLeft)
-                        const idx = widgetList.findIndex(e=>e.hash===curWidget.hash)
+                    const toSelectList =  curWidget.parent.childrenHashes
+                    .map(h=>widgetManager.widgets[h])
+                    .filter(w=>w.parent==curWidget.parent)
+                    if(toSelectList && toSelectList.length){
+                        toSelectList.sort((a,b)=>a.container.offsetLeft>b.container.offsetLeft)
+                        const idx = toSelectList.findIndex(e=>e.hash===curWidget.hash)
                         if(idx>=0){
-                            const nextIdx = (idx + (e.key == 'ArrowLeft'?-1:1)+widgetList.length) % widgetList.length
-                            toSelect = widgetList[nextIdx]
+                            const nextIdx = (idx + (e.key == 'ArrowLeft'?-1:1)+toSelectList.length) % toSelectList.length
+                            toSelect = toSelectList[nextIdx]
                         }
                     }
                 }

--- a/src/browser/js/app/editor/index.js
+++ b/src/browser/js/app/editor/index.js
@@ -131,7 +131,7 @@ var Editor = class Editor {
                 else if(e.key == 'ArrowDown' ){
                     const toSelectList =  curWidget.childrenHashes
                     .map(h=>widgetManager.widgets[h])
-                    .filter(w && w=>w.parent==curWidget)
+                    .filter(w=>w && w.parent==curWidget)
                     
                     if(toSelectList && toSelectList.length){
                             toSelectList.sort((a,b)=>a.container.offsetLeft>b.container.offsetLeft)
@@ -142,7 +142,7 @@ var Editor = class Editor {
                 else if((e.key == 'ArrowLeft') || (e.key == 'ArrowRight')){
                     const toSelectList =  curWidget.parent.childrenHashes
                     .map(h=>widgetManager.widgets[h])
-                    .filter(w && w=>w.parent==curWidget.parent)
+                    .filter(w=>w && w.parent==curWidget.parent)
                     if(toSelectList && toSelectList.length){
                         toSelectList.sort((a,b)=>a.container.offsetLeft>b.container.offsetLeft)
                         const idx = toSelectList.findIndex(e=>e.hash===curWidget.hash)

--- a/src/browser/js/app/editor/index.js
+++ b/src/browser/js/app/editor/index.js
@@ -134,7 +134,6 @@ var Editor = class Editor {
                     .filter(w=>w.parent==curWidget)
                     
                     if(toSelectList && toSelectList.length){
-                        // multiple objects can have the same id, need to check we're getting the child one
                             toSelectList.sort((a,b)=>a.container.offsetLeft>b.container.offsetLeft)
                             toSelect = toSelectList[0]
                     }

--- a/src/browser/js/app/editor/index.js
+++ b/src/browser/js/app/editor/index.js
@@ -131,7 +131,7 @@ var Editor = class Editor {
                 else if(e.key == 'ArrowDown' ){
                     const toSelectList =  curWidget.childrenHashes
                     .map(h=>widgetManager.widgets[h])
-                    .filter(w=>w.parent==curWidget)
+                    .filter(w && w=>w.parent==curWidget)
                     
                     if(toSelectList && toSelectList.length){
                             toSelectList.sort((a,b)=>a.container.offsetLeft>b.container.offsetLeft)
@@ -142,7 +142,7 @@ var Editor = class Editor {
                 else if((e.key == 'ArrowLeft') || (e.key == 'ArrowRight')){
                     const toSelectList =  curWidget.parent.childrenHashes
                     .map(h=>widgetManager.widgets[h])
-                    .filter(w=>w.parent==curWidget.parent)
+                    .filter(w && w=>w.parent==curWidget.parent)
                     if(toSelectList && toSelectList.length){
                         toSelectList.sort((a,b)=>a.container.offsetLeft>b.container.offsetLeft)
                         const idx = toSelectList.findIndex(e=>e.hash===curWidget.hash)


### PR DESCRIPTION
this allow to quickly change selected widget in editor
mostly needed when having panel without label : the panel is "invisible" so selecting one or the other has to be done via side panel...

mod + up/down => edit parent / child
mod + left / right => edit siblings

this PR looks functional to me but is still marked as WIP because : 

* the way I have to resolve child objects is kind of hacky because getProps('widgets') return Object (not widgets) without the hash info so I have to identify them by asserting equality with ('id','top','left','right') although even in case of multiple object sharing these, it wont generate bug

* another way is to use childrenHashes, but its filled with nested childrens too

* to navigate through siblings i use widget.container.offsetLeft, not sure thats the best though...



