### PR TITLE
use watchify to reduce re-build times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
   - added keyboard shortcut `mod + shift + a` for cancelling selection
   - added multi widget selection with mouse when `shift` is pressed
   - right-click doesn't modify current selection when `mod` or `shift` is pressed
+- formulas
+  - added `extend(x, y)` function for merging two objects
 
 ## 0.37.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - bug fixes
   - `@{parent}` calls not working consistently in clone widgets
   - `slider/pads`: inteverted ranges not working
+  - fix `doubleTap` for sliders with `snap` set to `true`
 - editor
   - removed widget deletion confirmation popup
   - properties categories can now be folded

--- a/package.json
+++ b/package.json
@@ -66,9 +66,9 @@
     "watch-js": "nodemon --watch src/browser/js -e js -x \"npm run build-js\"",
     "build-css": "node scripts/build-css.js",
     "build-js": "npm run build-launcher-js && npm run build-browser-js",
-    "build-browser-js": "node scripts/build-browser.js > app/browser/scripts.js",
+    "build-browser-js": "node scripts/build-browser.js",
     "build-launcher-js": "node scripts/build-launcher.js > app/launcher/scripts.js",
-    "watch-browser" : "node scripts/build-browser.js --watch",
+    "watch-browser": "node scripts/build-browser.js --watch",
     "deploy-docs": "node scripts/build-widgets-reference.js > resources/docs/widgets-reference.md && cd resources && mkdocs gh-deploy --clean && rm -rf site",
     "test": "npm run build"
   },

--- a/resources/docs/extras/advanced-property-syntax.md
+++ b/resources/docs/extras/advanced-property-syntax.md
@@ -85,6 +85,7 @@ Additionnal functions:
 - `length(x)`: returns the length of an array or string
 - `keys(x)`: returns an array of a given object's property names (from [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys))
 - `values(x)`: returns an array of a given object's own enumerable property values (from [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/values))
+- `extend(x, y)`: merges two objects into one
 
 !!! tip ""
     A single widget property can contain multiple formulas. Variables and functions declared in a formula are available to subsequent formulas in the same property definition.

--- a/src/browser/js/app/widgets/mixins/double_tap.js
+++ b/src/browser/js/app/widgets/mixins/double_tap.js
@@ -20,7 +20,8 @@ module.exports = (element, callback)=>{
 
         ) {
 
-            callback()
+            // execute callback at next cycle to ensure draginit events are resolved first
+            setTimeout(callback, 0)
             lastTapTime = 0
 
         } else {

--- a/src/browser/js/app/widgets/utils.js
+++ b/src/browser/js/app/widgets/utils.js
@@ -88,6 +88,7 @@ module.exports = {
             length: function(x) { return x.length },
             values: function(x) { return Object.values(x) },
             keys: function(x) { return Object.keys(x) },
+            extend: function(x, y) { return Object.assign(x, y) },
             timestamp: function() { return Date.now() },
             // basic relationnal to keep alphabetical string comparison (v4 change)
             equal:     function(a, b) { return a == b },


### PR DESCRIPTION
Hi again, I was tired to wait 12s build + page refresh at every changes made on my almost out of date osx-machine , this pr takes re-builds down to 2s  for me using watchify, so compiling only the needed part

this PR adds the new npm command : `watch-browser`

* feel free to change scripts name / implementation, thats just a proposal,
* i can add this to launcher too if needed

