### PR TITLE
add integrated html error and reloading when debuging

### DIFF
--- a/app/main/callbacks.js
+++ b/app/main/callbacks.js
@@ -5,7 +5,8 @@ var path = require('path'),
     {ipc} = require('./server'),
     {deepCopy} = require('./utils'),
     theme = require('./theme'),
-    chokidar = require('chokidar')
+    chokidar = require('chokidar'),
+    {BrowserWindow} = require('electron')
 
 var openedSessions = {},
     widgetHashTable = {},
@@ -293,6 +294,12 @@ module.exports =  {
 
     fullscreen: function(data) {
         window.setFullScreen(!window.isFullScreen())
+    },
+    
+    refresh: function(data) {
+        for (var w of BrowserWindow.getAllWindows()){
+            w.reload()
+        }
     },
 
     reloadCss:function(){

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "node": ">=6"
   },
   "devDependencies": {
+    "ansi-to-html": "^0.6.6",
     "watchify": "^3.11.0"
   }
 }

--- a/scripts/build-browser.js
+++ b/scripts/build-browser.js
@@ -10,6 +10,8 @@ var browserify = require('browserify'),
     prod = process.argv.indexOf('--prod') != -1,
     fast = process.argv.indexOf('--fast') != -1,
     watch = process.argv.indexOf('--watch') != -1,
+    autoRefresh = process.argv.indexOf('--auto-refresh') != -1,
+    WebSocket = require('ws'),
     b
 
 var inputPath = path.resolve(__dirname + '/../src/browser/js/index.js'),
@@ -59,12 +61,56 @@ if (watch) {
 }
 
 bundle()
+var pendingSocket
+const wsAddress = 'ws://127.0.0.1:8080/dev'
+if(autoRefresh){
+    var WS = require('../app/node_modules/ws')
+    pendingSocket = new WS(wsAddress)
+    pendingSocket.on('error', (err)=>{console.error(err)})
+    pendingSocket.on('open', ()=>{})
+    pendingSocket.on('close', ()=>{pendingSocket = null;})
+}
 
+var hasError = false
 function bundle() {
 
     var output =  b.bundle()
-    output.on('error', function(err) {console.error(new Error(err))})
+    output.on('end', (err)=> {
+        console.log('build successful',pendingSocket?'sending refresh':'')
+        if(autoRefresh && pendingSocket && hasError){
+            pendingSocket.send('["refresh"]')
+            hasError = false
+            //pendingSocket.close();
+        }
+    })
+    output.on('error', (err)=> {
+        console.error(err.stack)
+        var Convert = require('ansi-to-html');
+        var convert = new Convert(
+            {fg: '#0F0',
+            bg: '#000'});
+        const errFilePath = err.stack.split(':')?'file://'+err.stack.split(':')[1].trim()+':'+err.loc.line:''
+        let formattedStack = err.stack.replace(new RegExp(path.resolve(__dirname + '/..'), 'g'),'.');
+        // let stackWithoutAnsi = formattedStack.replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g,'')// escape ANSI codes
+        
+        
+        fs.createWriteStream(outputPath).write(`
+        window.onload = ()=>{
+            document.write(\`<body> <div>${convert.toHtml(formattedStack)}</div><button onclick="refresh()"></button></body>\`)
+            document.body.style['color']='#0F0'
+            document.body.style['white-space']='pre-wrap'
+            console.error(\`${errFilePath}\`)
+        }
+        `)
 
+        if(autoRefresh ){
+            if(pendingSocket){
+                pendingSocket.send('["refresh"]')
+            }
+        }
+  })
+    
+    
     if (!fast) output.pipe(exorcist(outputPath + '.map'))
 
     output.pipe(fs.createWriteStream(outputPath))


### PR DESCRIPTION
 when rebuilded reloading the page do either:
* display bug if unsuccessful
* show normal operation

running `npm run watch-browser -- --auto-refresh` trigger refresh at every new builds

 we can avoid ansi-to-html dependency if we don't want this PR to be that fancy