### PR TITLE
wip dynamic prop event system

### DIFF
--- a/src/browser/js/app/editor/index.js
+++ b/src/browser/js/app/editor/index.js
@@ -661,7 +661,7 @@ var Editor = class Editor {
 
             let w = this.selectedWidgets[i],
                 nW, nH
-
+            w.startPropChangeSet('resize',{fromEditor:true})
             if (i === 0 && ui) {
                 nW = ui.originalSize.width + deltaW
                 nH = ui.originalSize.height + deltaH
@@ -674,22 +674,23 @@ var Editor = class Editor {
             if (w.props.width !== undefined) {
                 var newWidth = Math.max(nW, GRIDWIDTH) / PXSCALE
                 if (typeof w.props.width === 'string' && w.props.width.indexOf('%') > -1) {
-                    w.props.width = (100 * PXSCALE * newWidth / w.container.parentNode.offsetWidth).toFixed(2) + '%'
-                } else {
-                    w.props.width = newWidth
+                    newWidth = (100 * PXSCALE * newWidth / w.container.parentNode.offsetWidth).toFixed(2) + '%'
                 }
+                w.setProp('width',newWidth)
+
             }
 
             if (w.props.height !== undefined) {
                 var newHeight = Math.max(nH, GRIDWIDTH) / PXSCALE
                 if (typeof w.props.height === 'string' && w.props.height.indexOf('%') > -1) {
-                    w.props.height = (100 * PXSCALE * newHeight / w.container.parentNode.offsetHeight).toFixed(2) + '%'
-                } else {
-                    w.props.height = newHeight
+                    newHeight = (100 * PXSCALE * newHeight / w.container.parentNode.offsetHeight).toFixed(2) + '%'
                 }
+                w.setProp('height',newHeight)
             }
+            w.applyPropChangeSet()//'resize'
 
-            if (w.props.width !== undefined || w.props.height !== undefined) newWidgets.push(updateWidget(w, {preventSelect: this.selectedWidgets.length > 1}))
+            if (w.props.width !== undefined || w.props.height !== undefined) 
+                newWidgets.push(w)
 
         }
 
@@ -707,20 +708,23 @@ var Editor = class Editor {
 
         for (var w of this.selectedWidgets) {
 
+            w.startPropChangeSet('move',{fromEditor:true})
+            
             var newTop = w.container.offsetTop / PXSCALE + deltaY
             if (typeof w.props.top === 'string' && w.props.top.indexOf('%') > -1) {
-                w.props.top = (100 * PXSCALE * newTop / w.container.parentNode.offsetHeight).toFixed(2) + '%'
-            } else {
-                w.props.top = newTop
-            }
+                newtop = (100 * PXSCALE * newTop / w.container.parentNode.offsetHeight).toFixed(2) + '%'
+            } 
+            w.setProp('top', newTop)
+            
             var newLeft = w.container.offsetLeft / PXSCALE + deltaX
             if (typeof w.props.left === 'string' && w.props.left.indexOf('%') > -1) {
-                w.props.left = (100 * PXSCALE * newLeft / w.container.parentNode.offsetWidth).toFixed(2) + '%'
-            } else {
-                w.props.left = newLeft
+                newLeft =  (100 * PXSCALE * newLeft / w.container.parentNode.offsetWidth).toFixed(2) + '%'
             }
+            w.setProp('left', newLeft)
+            
 
-            newWidgets.push(updateWidget(w, {preventSelect: this.selectedWidgets.length > 1}))
+            w.applyPropChangeSet()//'move'
+            newWidgets.push(w)
 
         }
 

--- a/src/browser/js/app/events/event-emitter.js
+++ b/src/browser/js/app/events/event-emitter.js
@@ -94,15 +94,17 @@ module.exports = class EventEmitter extends WolfyEventEmitter {
 
     }
 
-    removeEventContext(context) {
+    removeEventContext(context,evt) {
 
         var events = this._contextEvents[context.hash]
 
         if (events) {
             for (var i = 0; i < events.length; i++) {
-                this.removeListener(events[i][0], events[i][1])
+                if(!evt || events[i][0]==evt){
+                    this.removeListener(events[i][0], events[i][1])
+                }
             }
-            delete this._contextEvents[context.hash]
+            if(this._contextEvents[context.hash].length==0) delete this._contextEvents[context.hash]
         }
 
     }

--- a/src/browser/js/app/widgets/common/osc-receiver.js
+++ b/src/browser/js/app/widgets/common/osc-receiver.js
@@ -11,7 +11,7 @@ module.exports = class OscReceiver {
         }
 
         this.parent = parent
-        this.propName = propName
+        this.propNames = [propName]
         this.bindedCallback = this.callback.bind(this)
         this.setAddress(address)
 
@@ -28,6 +28,10 @@ module.exports = class OscReceiver {
 
         }
 
+    }
+    
+    addProp(propName){
+        if(!this.propNames.includes(propName))this.propNames.push(propName)
     }
 
     callback(args) {
@@ -46,7 +50,7 @@ module.exports = class OscReceiver {
             } catch (err) {
                 this.value = val
             }
-            this.parent.updateProps([this.propName], this.parent)
+            this.parent.updateProps(this.propNames, this.parent)
         }
 
     }

--- a/src/browser/js/app/widgets/common/widget.js
+++ b/src/browser/js/app/widgets/common/widget.js
@@ -567,7 +567,7 @@ class Widget extends EventEmitter {
         const changedSetName = this.changedSetName
         const changedProps = this.changedPropSet[changedSetName]
         if (changedProps){
-            this._applyChangedProps(this.changedPropSet[changedSetName],options)
+            this._applyChangedProps(this.changedPropSet[changedSetName],this.changedSetOptions)
             delete this.changedPropSet[changedSetName] 
         }
         this.changedSetOptions = {}

--- a/src/browser/js/app/widgets/containers/clone.js
+++ b/src/browser/js/app/widgets/containers/clone.js
@@ -162,6 +162,23 @@ class Clone extends Container {
             w.container.classList.add('not-editable')
         }
 
+
+        if(this.cloneTarget){
+            this.cloneTarget.on(`prop-changed`,(e)=>{
+                let {id, props,widget, options} = e;
+                if(options.fromEditor){ // we only spread values changed from editor
+                const equivalentObj = this.findClonedFromWidget(widget)
+                if(equivalentObj){
+                    equivalentObj.startPropChangeSet('cloneChange',{...options,isResolved:false})
+                    for(var p of props){
+                        equivalentObj.setProp(p.propName,widget.props[p.propName])
+                    }
+                    equivalentObj.applyPropChangeSet()
+                }
+            }
+            })
+
+
         // listen for cloneTarget's deletion
         // if it is just edited, its recreation will be catched by the global 'widget-created' event handler
         this.cloneTarget.on('widget-removed', (e)=>{
@@ -188,11 +205,38 @@ class Clone extends Container {
             resize.check(this.container)
 
         }, {context: this})
+    }
 
         this.cloneLock = false
 
     }
 
+    findClonedFromWidget(widget){
+        // this return the equivalent widget contained in clone if widget inherits from cloneTarget
+        if(!this.cloneTarget)return 
+
+        if(widget===this.cloneTarget){return this.cloneTarget}
+        let insp = widget;
+        let address = []
+        while(insp && insp.parent!==widgetManager){
+            if(insp===this.cloneTarget){break}
+            if(insp.cachedProps.type==="clone" ){return null}
+            address.push(insp.props['id']) // use non resolved id prop
+            insp = insp.parent
+        }
+        address = address.reverse()
+        if(insp===this.cloneTarget){
+            insp = this.children[0]
+           for(var i  of address){
+            insp = insp.children.find(e=>e.props['id']===i)
+            if(!insp)break
+           }
+           return  insp
+        }
+        
+
+    }
+    
     onPropChanged(propName, options, oldPropValue) {
 
         if (super.onPropChanged(...arguments)) return true


### PR DESCRIPTION
Hi again, thats a simplified version of dynamic events : 
**features :** 
* clone are fast to rebuild when moved
*  modifying any dynamicProps never rebuilds widgets so if a different prop of the same widget is used elsewhere, it wont be notified (these loop can get quite big), i.e modifying a color of a button was triggering reevaluation of all widget listening to the value of the button

**while doing that I needed to modify other parts :**
*  I've found a bug in OSC{} , where multiple props in a widget can not all be notified if they use the same OSC address
* i needed to add event specific removeContext functionality (when dealing with linkedProps and linkedPropsValue)
* I kept the listener that was deleted on the first edit of edit-field input (I think it was there because widget recreation on prop changed was triggering a rebuild of the editor every time)


**usability**
* I've tested it quite intensely and it seems to respond correctly, i.e detaching and adding listeners on the go.
* the part I havent tested yet is the integration with undo/redo, I suspect that it needs to comply with the setters

**my personal thought :** 
 - obviously the complexity is increased compared to systematic widget rebuild, but I think that's a true bottle neck (at least for my use) and it forces a unified syntax to modify props
- the complexity may seem to add some heavy array manipulation  for each propChange but it is far from the rebuild overhead
- I'm quite open to discuss on the implementation, I'm not forcing o-s-c to go this way as it can be risky to assume the hypothetical bug, It's more that I personally need the functionality, so I share!


 