### PR TITLE
wip traversing same Widget

### DIFF
--- a/src/browser/js/app/events/utils.js
+++ b/src/browser/js/app/events/utils.js
@@ -22,6 +22,7 @@ module.exports = {
             shiftKey: e.shiftKey,
             inertia: e.multitouch ? 1 : e.inertia,
             traversing: e.traversing,
+            traversingType: e.traversingType,
             traversingContainer: e.traversingContainer,
             multitouch: e.multitouch,
             isTouch: e instanceof Touch
@@ -60,6 +61,7 @@ module.exports = {
 
             if (previousEvent.traversing) {
                 event.traversing = previousEvent.traversing
+                event.traversingType = previousEvent.traversingType
                 event.traversingContainer = previousEvent.traversingContainer
             }
 

--- a/src/browser/js/app/locales/en.js
+++ b/src/browser/js/app/locales/en.js
@@ -53,6 +53,7 @@ module.exports = {
 
     // traversing
     traversing_on: 'On',
+    traversing_smart: 'Smart',
     traversing_off: 'Off',
 
     // misc

--- a/src/browser/js/app/locales/fr.js
+++ b/src/browser/js/app/locales/fr.js
@@ -53,6 +53,7 @@ module.exports = {
 
     // traversing
     traversing_on: 'On',
+    traversing_smart: 'Auto',
     traversing_off: 'Off',
 
     // misc

--- a/src/browser/js/app/locales/ru.js
+++ b/src/browser/js/app/locales/ru.js
@@ -53,6 +53,7 @@ module.exports = { // @https://github.com/suhr
 
     // traversing
     traversing_on: 'Вкл',
+    traversing_smart: 'Умный',
     traversing_off: 'Выкл',
 
     // misc

--- a/src/browser/js/app/ui/sidepanel.js
+++ b/src/browser/js/app/ui/sidepanel.js
@@ -53,41 +53,33 @@ var sidepanelData = [
         actions: [
             {
                 title: locales('traversing_on'),
-                action:()=>{
-                    DOM.each(document, '.traversingDisable, .traversingSame', (el)=>{
+                action:(el)=>{
+                    DOM.each(el.parentNode, 'a', (el)=>{
                         el.classList.remove('on')
                     })
-                    DOM.each(document, '.traversingEnable', (el)=>{
-                        el.classList.add('on')
-                    })
-                    // disableTraversingGestures(document.getElementById('container'))
+                    el.classList.add('on')
                     enableTraversingGestures(document.getElementById('container'))
                 },
                 class:'traversingEnable'
             },
             {
-                title: locales('traversing_same'),
-                action:()=>{
-                    DOM.each(document, '.traversingEnable, .traversingDisable', (el)=>{
+                title: locales('traversing_smart'),
+                action:(el)=>{
+                    DOM.each(el.parentNode, 'a', (el)=>{
                         el.classList.remove('on')
                     })
-                    DOM.each(document, '.traversingSame', (el)=>{
-                        el.classList.add('on')
-                    })
-                    // disableTraversingGestures(document.getElementById('container'))
-                    enableTraversingGestures(document.getElementById('container'),{sameWidgetPolicy:true})
+                    el.classList.add('on')
+                    enableTraversingGestures(document.getElementById('container'), {smart: true})
                 },
-                class:'traversingSame'
+                class:'traversingEnable'
             },
             {
                 title: locales('traversing_off'),
-                action:()=>{
-                    DOM.each(document, '.traversingEnable, .traversingSame', (el)=>{
+                action:(el)=>{
+                    DOM.each(el.parentNode, 'a', (el)=>{
                         el.classList.remove('on')
                     })
-                    DOM.each(document, '.traversingDisable', (el)=>{
-                        el.classList.add('on')
-                    })
+                    el.classList.add('on')
                     disableTraversingGestures(document.getElementById('container'))
                 },
                 class:'traversingDisable on'

--- a/src/browser/js/app/ui/sidepanel.js
+++ b/src/browser/js/app/ui/sidepanel.js
@@ -124,7 +124,7 @@ for (let i in sidepanelData) {
         let actionData = data.actions[j],
             element = DOM.create(`<a class="btn ${actionData.class || ''}">${actionData.title}</a>`)
 
-        if (actionData.action) element.addEventListener('click', actionData.action)
+        if (actionData.action) element.addEventListener('click', ()=>{actionData.action(element)})
 
         wrapper.appendChild(element)
     }


### PR DESCRIPTION
Hey, 

just an Idea, having a third option to have traversing gesture only modifying widget of the same class that the first pressed, as it's usually (at least for me) weird to move a slider and a button in the same gesture (I even think that it is almost never desirable..). and in some layout realy useful (think trackslots, with, volumes and mute buttons, you either want to traverse thru volumes either thru mutes, even if they are in the way, even more, you want to be sure to modify the style of first touched (a bit safer when playing live)

TODOs : 
- adapt translation
- align buttons in row
- ensure no listener doubles are generated when switched

Again change every thing you need , and let me know if its a desired feature!