### PR TITLE
fix typo preventing error logs

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -35,7 +35,7 @@ module.exports = (opt) => {
 
         var output =  b.bundle()
 
-        output = output.pipe(exorcist(outputPath + '.map'))
+        output.pipe(exorcist(outputPath + '.map'))
         output.pipe(fs.createWriteStream(outputPath))
 
         return output


### PR DESCRIPTION
Hi, I think it's a typo, in any case, it definitely prevents the errors to pass through for me, weirdly enough, it was catching the end event, but the one triggered by the sourcemap pipe....