### PR TITLE
resolveProp : compare cached id when checking undefined

### DIFF
--- a/src/client/app/widgets/common/widget.js
+++ b/src/client/app/widgets/common/widget.js
@@ -494,8 +494,8 @@ class Widget extends EventEmitter {
 
                     if (widgets[i].props[k] !== undefined || k === 'value') {
 
-                        if (k !== 'value' && originalPropName == k && widgets[i].cachedProps.id == originalWidget.cachedProps.id) {
-                            return undefined
+                        if (k !== 'value' && originalPropName === k && widgets[i] === originalWidget) {
+                            return 'ERR_CIRCULAR_REF'
                         }
 
                         var r = k == 'value' ?

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,3 +1,5 @@
+require('source-map-support').install({handleUncaughtExceptions: false})
+
 var dev = process.argv[0].includes('node_modules'),
     settings = require('./settings')
 
@@ -6,8 +8,6 @@ var serverStarted
 function nodeMode() {
 
     console.warn('Running with node')
-
-    require('source-map-support').install({handleUncaughtExceptions: false})
 
     if (!settings.read('noGui')) {
         settings.cli = true


### PR DESCRIPTION
~~not sure to understand fully the role of returning undefined in here, probably to avoid infinite loops,~~ but comparing ids that are set, dynamically ( I'm using a lot ids like : @{parent.address}/@{this.label} ) will trigger this line while the cached prop values are differents. I 'm not sure of this change but let me know what you think of it