### PR TITLE
[proposal] prevent sleep if fullscreen

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "nanomorph": "5.1.3",
     "node-sass": "4.9.4",
     "nodemon": "1.18.5",
+    "nosleep.js": "^0.7.0",
     "osc": "2.2.4",
     "python-shell": "1.0.6",
     "scope-css": "1.2.1",

--- a/src/client/app/locales/en.js
+++ b/src/client/app/locales/en.js
@@ -39,6 +39,7 @@ module.exports = {
 
     // sidepanel
     sidepanel_fs: 'Fullscreen',
+    sidepanel_nosleep: 'Stay awake',
     sidepanel_state: 'State',
     sidepanel_traversing: 'Traversing gestures',
     sidepanel_editor: 'Editor',

--- a/src/client/app/locales/fr.js
+++ b/src/client/app/locales/fr.js
@@ -39,6 +39,7 @@ module.exports = {
 
     // sidepanel
     sidepanel_fs: 'Plein Écran',
+    sidepanel_nosleep: 'Rester allumé',
     sidepanel_state: 'État',
     sidepanel_traversing: 'Gestes traversants',
     sidepanel_editor: 'Éditeur',

--- a/src/client/app/locales/ru.js
+++ b/src/client/app/locales/ru.js
@@ -39,6 +39,7 @@ module.exports = { // @https://github.com/suhr
 
     // sidepanel
     sidepanel_fs: 'Полный экран',
+    sidepanel_nosleep: 'бодрствовать',
     sidepanel_state: 'Состояние',
     sidepanel_traversing: 'Скользящие жесты',
     sidepanel_editor: 'Редактор',

--- a/src/client/app/ui/fullscreen.js
+++ b/src/client/app/ui/fullscreen.js
@@ -1,7 +1,6 @@
 var screenfull = require('screenfull'),
     {Popup} = require('./utils'),
-    locales = require('../locales'),
-    NoSleep = require('nosleep.js')
+    locales = require('../locales')
 
 var fullscreen
 
@@ -38,16 +37,5 @@ if (screenfull.enabled) {
 
 }
 
-
-fullscreen.on('change', () => {
-    var noSleep = new NoSleep()
-
-    if(screenfull.isFullscreen){
-        noSleep.enable()
-    }
-    else{
-        noSleep.disable()
-    }
-})
 
 module.exports = fullscreen

--- a/src/client/app/ui/fullscreen.js
+++ b/src/client/app/ui/fullscreen.js
@@ -1,6 +1,7 @@
 var screenfull = require('screenfull'),
     {Popup} = require('./utils'),
-    locales = require('../locales')
+    locales = require('../locales'),
+    NoSleep = require('nosleep.js')
 
 var fullscreen
 
@@ -36,5 +37,17 @@ if (screenfull.enabled) {
     fullscreen = new IOSFullScreen()
 
 }
+
+
+fullscreen.on('change', () => {
+    var noSleep = new NoSleep()
+
+    if(screenfull.isFullscreen){
+      noSleep.enable()
+    }
+    else{
+      noSleep.disable()
+    }
+})
 
 module.exports = fullscreen

--- a/src/client/app/ui/fullscreen.js
+++ b/src/client/app/ui/fullscreen.js
@@ -43,10 +43,10 @@ fullscreen.on('change', () => {
     var noSleep = new NoSleep()
 
     if(screenfull.isFullscreen){
-      noSleep.enable()
+        noSleep.enable()
     }
     else{
-      noSleep.disable()
+        noSleep.disable()
     }
 })
 

--- a/src/client/app/ui/sidepanel.js
+++ b/src/client/app/ui/sidepanel.js
@@ -123,7 +123,7 @@ var sidepanelData = [
 ]
 
 
-if (true || navigator.userAgent.match(/Android|iPhone|iPad|iPod/i)) {
+if (navigator.userAgent.match(/Android|iPhone|iPad|iPod/i)) {
 
     var NoSleep = require('nosleep.js'),
         noSleep = new NoSleep(),

--- a/src/client/app/ui/sidepanel.js
+++ b/src/client/app/ui/sidepanel.js
@@ -16,7 +16,7 @@ var sidepanelData = [
                 action:()=>{
                     if (fullscreen.enabled) fullscreen.toggle()
                 },
-                class:'fullscreenToggle' + (!fullscreen.enabled ||  ELECTRON_FULLSCREEN ? ' disabled' : '')
+                class:'toggle fullscreenToggle' + (!fullscreen.enabled ||  ELECTRON_FULLSCREEN ? ' disabled' : '')
             }
 
         ]
@@ -121,6 +121,30 @@ var sidepanelData = [
         ]
     },
 ]
+
+
+if (true || navigator.userAgent.match(/Android|iPhone|iPad|iPod/i)) {
+
+    var NoSleep = require('nosleep.js'),
+        noSleep = new NoSleep(),
+        noSleepState = false
+
+    sidepanelData[0].actions.push({
+        title: locales('sidepanel_nosleep'),
+        class: 'toggle',
+        action:(el)=>{
+            noSleepState = el.classList.toggle('on')
+            if (noSleepState) {
+                noSleep.enable()
+            } else {
+                noSleep.disable()
+            }
+        }
+    })
+
+}
+
+
 
 var options = html`<ul id="options"></ul>`
 

--- a/src/scss/sidepanel.scss
+++ b/src/scss/sidepanel.scss
@@ -98,7 +98,7 @@
         &.on {
             z-index: 0;
             color: var(--color-custom);
-            &:not(.fullscreenToggle) {
+            &:not(.toggle) {
                 pointer-events: none;
             }
             &:after {


### PR DESCRIPTION
hi,
preventing sleep is a critical feature I think, the usability of any interface becomes really low if you need to wake the app up often or if you need to manage sleep mode externaly..

So I just added nosleep.js to prevent sleep when fullscreen is toggled.

under the hood, nosleep just add an invisible video and sets play on it to prevent the browser to go to sleep, hackish, but working...

we may need to check that it doesn't alter global performance, but I'm not sure how..
