### PR TITLE
Resolve special char "~" on Dialog Box's paths. "~" is resolved …

### DIFF
--- a/src/server/callbacks.js
+++ b/src/server/callbacks.js
@@ -417,7 +417,16 @@ module.exports =  {
 
         var p = process.env[(process.platform == 'win32') ? 'USERPROFILE' : 'HOME']
 
-        if (data.path) p = path.resolve(...data.path)
+        if (data.path) {
+            // Resolve '~' to user's home directory
+            if (data.path[0].startsWith('~')) {
+                p = data.path[0].replace( "~", p );
+            }
+            else {
+                p = path.resolve(...data.path)
+            }
+            //console.log(`Resolved path: ${p}`);
+        }
 
         var root = settings.read('remote-root')
         if (root && !p.includes(root)) p = root

--- a/src/server/callbacks.js
+++ b/src/server/callbacks.js
@@ -420,7 +420,7 @@ module.exports =  {
         if (data.path) {
             // Resolve '~' to user's home directory
             if (data.path[0].startsWith('~')) {
-                p = data.path[0].replace( "~", p );
+                p = data.path[0].replace( '~', p )
             }
             else {
                 p = path.resolve(...data.path)


### PR DESCRIPTION
Open a dialog box in any folder found in a user's home directory. e.g. the /Documents folder.
Add a special char "~"  to the directory field and it is resolved as the user's home directory on the server side.

Example: Open a Dialog Box on user's Documents folder with "~/Documents"