### PR TITLE
Add fieldValidator property for input widget

### DIFF
--- a/src/client/widgets/basics/input.js
+++ b/src/client/widgets/basics/input.js
@@ -19,7 +19,11 @@ class Input extends Canvas {
                 unit: {type: 'string', value: '', help: 'Unit will be appended to the displayed widget\'s value (it doesn\'t affect osc messages)'},
             },
             class_specific: {
-                asYouType: {type: 'boolean', value: false, help: 'Set to `true` to make the input send its value at each keystroke'}
+                asYouType: {type: 'boolean', value: false, help: 'Set to `true` to make the input send its value at each keystroke'},
+                fieldValidator: {type: 'string|boolean', value: false, help: [
+                    'Set to `abc` to make the input reject all characters, except a, b or c',
+                    '`0-9` will only allow integer to be entered',
+                    '`a-z` will only allow lowercase characters']}
             }
         })
 
@@ -37,6 +41,7 @@ class Input extends Canvas {
         this.stringValue = ''
         this.focused = false
         this.tabKeyBlur = false
+        this.fieldValidator = false
 
         if (this.getProp('vertical')) this.widget.classList.add('vertical')
         if (this.getProp('align') === 'left') this.widget.classList.add('left')
@@ -53,6 +58,7 @@ class Input extends Canvas {
                 this.tabKeyBlur = false
             })
             var asYouType = this.getProp('asYouType')
+            this.fieldValidator = new RegExp('[^'+this.getProp('fieldValidator')+']', 'g')
             this.input.addEventListener('keydown', (e)=>{
                 if (e.keyCode === 13) this.blur() // enter
                 else if (e.keyCode === 27) this.blur(false) // esc
@@ -95,6 +101,9 @@ class Input extends Canvas {
 
     inputChange() {
 
+        if (this.fieldValidator) {
+            this.input.value = this.input.value.replace(this.fieldValidator, '');
+        }
         this.setValue(this.input.value, {sync:true, send:true})
 
     }

--- a/src/client/widgets/basics/input.js
+++ b/src/client/widgets/basics/input.js
@@ -58,7 +58,9 @@ class Input extends Canvas {
                 this.tabKeyBlur = false
             })
             var asYouType = this.getProp('asYouType')
-            this.fieldValidator = new RegExp('[^'+this.getProp('fieldValidator')+']', 'g')
+            if (this.getProp('fieldValidator')) {
+                this.fieldValidator = new RegExp('[^'+this.getProp('fieldValidator')+']', 'g')
+            }
             this.input.addEventListener('keydown', (e)=>{
                 if (e.keyCode === 13) this.blur() // enter
                 else if (e.keyCode === 27) this.blur(false) // esc

--- a/src/client/widgets/basics/input.js
+++ b/src/client/widgets/basics/input.js
@@ -41,7 +41,7 @@ class Input extends Canvas {
         this.stringValue = ''
         this.focused = false
         this.tabKeyBlur = false
-        this.fieldValidator = false
+        this.fieldValidator = null
 
         if (this.getProp('vertical')) this.widget.classList.add('vertical')
         if (this.getProp('align') === 'left') this.widget.classList.add('left')


### PR DESCRIPTION
Based on a RegExp, this added property allows to forbid non matching character typed in a input widget.
**Note**: Because this is based on RegExp, a few char must be escaped (`.` and `\` for example)

For now, field validation takes place after the user validate the new value (after pressing Enter)
It would be fine to do this while the user is typing, especially to handle the `asYouType` property as well.

I'm submitting this MR early so it can be discussed what changes are needed and if this added feature is useful or not.

**Usage**: If fieldValidator is set to `0-9\.`, only digits and decimal point will be allowed