### PR TITLE
Build rpm packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ node_js:
 before_install:
   - sudo dpkg --add-architecture i386
   - sudo apt-get update -qq
-  - sudo apt-get install -qq wine fakeroot xvfb python3.10 python3-pip python3-setuptools
+  - sudo apt-get install -qq wine fakeroot xvfb python3.10 python3-pip python3-setuptools rpm
   - python3 -m pip install mkdocs
   - python3 -m pip install mkdocs-material
 install: npm install
@@ -33,11 +33,13 @@ before_deploy:
   - wget https://github.com/jean-emmanuel/open-stage-control-midi/releases/latest/download/osc-midi-osx && chmod +x osc-midi-osx && echo "true" > osc-midi.json
   - cd $TRAVIS_BUILD_DIR
   - npm run deb64
+  - npm run rpm64
   - cd dist
   - mkdir packages
   - mv open-stage-control-node   open-stage-control_${VERSION}_node
   - mv open-stage-control-win32-x64    open-stage-control_${VERSION}_win32-x64
-  - mv open-stage-control-linux-x64/*.deb packages/open-stage-control_${VERSION}_amd64.deb
+  - mv open-stage-control-linux-x64/*.deb packages/
+  - mv open-stage-control-linux-x64/*.rpm packages/
   - mv open-stage-control-linux-x64    open-stage-control_${VERSION}_linux-x64
   - zip -q -r --symlinks packages/open-stage-control_${VERSION}_osx.zip open-stage-control-darwin-x64/open-stage-control.app
   - zip -q -r packages/open-stage-control_${VERSION}_node.zip     open-stage-control_${VERSION}_node

--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
   },
   "optionalDependencies": {
     "electron": "15.1.0",
-    "electron-installer-debian": "3.1.0"
+    "electron-installer-debian": "3.1.0",
+    "electron-installer-redhat": "3.4.0"
   },
   "scripts": {
     "postinstall": "echo '\\033[36m=> Dependencies installed successfully. Run \"npm run build\" to build the assets.\\033[0m\n'",
@@ -91,6 +92,7 @@
     "package": "node scripts/package.js",
     "package-node": "node scripts/package-node.js",
     "deb64": "electron-installer-debian --src dist/open-stage-control-linux-x64/ --arch amd64 --dest dist/open-stage-control-linux-x64/ --icon resources/images/logo.png",
+    "rpm64": "electron-installer-redhat --src dist/open-stage-control-linux-x64/ --arch x86_64 --dest dist/open-stage-control-linux-x64/ --icon resources/images/logo.png",
     "build-css": "node scripts/build-css.js",
     "build-js": "npm run build-launcher-js && npm run build-client-js && npm run build-server-js",
     "build-client-js": "node scripts/build-client.js",


### PR DESCRIPTION
Currently debs and zips are the only packaging methods. A new npm script "rpm64" enables building RPM packages for x86_64 using electron-installer-redhat. RPM packages can be installed on various Linux distributions such as RHEL, CentOS, Fedora, and more.