### PR TITLE
server: Print backtraces for errors in UDP handler

### DIFF
--- a/src/server/osc/udp.js
+++ b/src/server/osc/udp.js
@@ -14,7 +14,7 @@ oscUDPServer.on('error', function(e) {
     if (e.code === 'EADDRINUSE') {
         console.error(`(ERROR, UDP) could not open port ${oscInPort} (already in use) `)
     } else {
-        console.error(`(ERROR, UDP) ${e.message}`)
+        console.error('(ERROR, UDP)', e)
     }
 })
 


### PR DESCRIPTION
This applies to errors in e.g. the oscInFilter defined by a custom plugin module. Previously, just the exception backtrace was shown, without any indication of the exception type or where the error occurred, e.g.:

    (ERROR, UDP) links is not defined

With this commit, the full exception including backtrace is printed, making debugging a lot easier, e.g.:

    (ERROR, UDP) ReferenceError: links is not defined
	at CustomModule.oscInFilter (/app/custom-module.js:221:83)
	at OscServer.oscInFilter (/open-stage-control/app/server/src/server/osc/index.js:148:1)
	at OscServer.oscInHandler (/open-stage-control/app/server/src/server/osc/index.js:162:1)
	at OscServer.oscInHandlerWrapper (/open-stage-control/app/server/src/server/osc/index.js:174:1)
	at osc.UDPPort.emit (node:events:394:28)
	at Object.osc.firePacketEvents (/open-stage-control/app/server/node_modules/osc/src/osc-transports.js:25:1)
	at osc.UDPPort.p.decodeOSC (/open-stage-control/app/server/node_modules/osc/src/osc-transports.js:85:1)