### PR TITLE
custom-module: Call reload() function on auto-reload

### DIFF
--- a/resources/docs/docs/custom-module/custom-module.md
+++ b/resources/docs/docs/custom-module/custom-module.md
@@ -16,7 +16,14 @@ Using the server's `custom-module` option, users can load a custom javascript mo
 module.exports = {
 
     init: function(){
-        // this will be executed once when the osc server starts
+        // this will be executed once when the osc server starts after
+        // connections are set up
+        // it is called for the main module only
+    },
+
+    reload: function(){
+        // this will be executed after the custom module is reloaded
+        // it is called for the main module only
     },
 
     oscInFilter:function(data){
@@ -48,7 +55,8 @@ module.exports = {
     },
 
     unload: function(){
-        // this will be executed when the custom module is reloaded
+        // this will be executed before the custom module is reloaded
+        // it is called for all modules, including other loaded modules
     },
 
 }
@@ -168,7 +176,7 @@ for (var ip in tcpServer.clients) {
 
 ## Autoreload
 
-Custom modules (including submodules loaded with `require()`) are reloaded automatically when they are modified. Upon reload, timers (`setTimeout` and `setInterval`) and event listeners (added to the  `app` object) are reset.
+Custom modules (including submodules loaded with `require()`) are reloaded automatically when they are modified. Upon reload, timers (`setTimeout` and `setInterval`) and event listeners (added to the  `app` object) are reset. After each reload the `module.exports.reload()` function (if any) is called.
 
 The `global` object persists accross reloads.
 

--- a/resources/docs/docs/custom-module/examples.md
+++ b/resources/docs/docs/custom-module/examples.md
@@ -378,6 +378,11 @@ module.exports = {
             if (m.init) m.init()
         }
     },
+    reload: function(){
+        for (var m of submodules) {
+            if (m.reload) m.reload()
+        }
+    },
     oscInFilter: function(data){
 
         for (var m of submodules) {

--- a/resources/docs/docs/custom-module/examples.md
+++ b/resources/docs/docs/custom-module/examples.md
@@ -378,11 +378,6 @@ module.exports = {
             if (m.init) m.init()
         }
     },
-    unload: function(){
-        for (var m of submodules) {
-            if (m.unload) m.unload()
-        }
-    },
     oscInFilter: function(data){
 
         for (var m of submodules) {

--- a/src/server/custom-module.js
+++ b/src/server/custom-module.js
@@ -195,6 +195,15 @@ class CustomModule {
         console.log('(INFO) Reloading custom module...')
         if (this.load()) {
             console.log('(INFO) Custom module reloaded successfully')
+
+            if (this.module.exports && this.module.exports.reload) {
+                try {
+                    this.module.exports.reload()
+                } catch(e) {
+                    console.error('(ERROR) Error while calling custom module reload function')
+                    console.error(e)
+                }
+            }
         } else {
             console.error('(ERROR) Failed to reload custom module')
             this.unload()


### PR DESCRIPTION
This allows modules to re-initialize any state they need whenever the module is reloaded.

Without this, any such initialization can also be done in the top level of the custom module, but this has two problems:

 1. Top-level module code runs on load and reload, and for the initial load, it runs *before* the connections are set up, so trying to use send() would produce an error on load (not reload).

 2. Top-level module code runs for the primary custom module, but also for any nested modules, removing control about the process and ordering from the primary custom module. In addition, a module that can be used both as primary and nested module, there is no clean way to distinguish between these cases.

Both of these problems can be solved by doing some bookkeeping in the global object, but that produces messy code.

This commit allows modules to define a reload() function, which is called (for the primary module only) after the module is reloaded. This means that any initialization for the first load can be done in init() and for reloads in reload(), and in both cases all connections will already have been set up solving issue 1. In addition, neither of these functions are called for nested modules, solving issue 2 (and the primary module can then stil explicitly call a reload function on nested modules if needed, as shown in the examples).