### PR TITLE
remote control: Add `/SESSION/CREATE` command

### DIFF
--- a/resources/docs/docs/custom-module/examples.md
+++ b/resources/docs/docs/custom-module/examples.md
@@ -404,3 +404,53 @@ module.exports = {
     }
 }
 ```
+
+## Dynamic widget creation
+```js
+function create_widgets() {
+    receive('', '', '/EDIT', 'root', {
+        widgets: [{
+            type: 'panel',
+            id: 'my_panel',
+            layout: 'vertical',
+            width: '100%',
+            height: '200%',
+            widgets: [
+                {
+                    type: 'text',
+                    id: 'notice',
+                    value: 'Hello, world!',
+                    width: '100%',
+                },
+                {
+                    type: 'button',
+                    id: 'button',
+                    address: '/foo',
+                    preArgs: [1],
+                },
+            ]
+        }]
+    })
+}
+
+module.exports = {
+    reload: function(){
+        // When reloading this script, recreate all widgets
+        create_widgets()
+    },
+}
+
+// Called when a client is opened
+//
+// This can be omitted if you want to dynamically create additional widgets on top
+// of a session loaded with --load
+app.once('open', () => {
+    app.once('sessionSetPath', (data) => {
+        // Session was created
+        create_widgets()
+    })
+    // Create a new empty session
+    receive('', '', '/SESSION/CREATE')
+})
+
+```

--- a/resources/docs/docs/remote-control.md
+++ b/resources/docs/docs/remote-control.md
@@ -202,6 +202,11 @@ Save state session to `path.state`.
 
 ----
 
+#### `/SESSION/CREATE`
+
+Create a new empty session
+
+----
 #### `/SESSION/OPEN path.json`
 
 Open session file `path.json`.

--- a/src/client/remote-control.js
+++ b/src/client/remote-control.js
@@ -264,6 +264,11 @@ var callbacks = {
         console.log(args)
 
     },
+    '/SESSION/CREATE': function(args) {
+
+        sessionManager.create()
+
+    },
     '/SESSION/OPEN': function(args) {
 
         if (!Array.isArray(args)) args = [args]


### PR DESCRIPTION
This allows creating a new empty session. This is useful for projects that want to dynamically create the entire session using a custom module.

Without this, you can also create an empty session json file and load that with `--load`, but then you would have to manage that file, and if you accidentaly press control-s, it gets overwritten to contain any dynamically created widgets.

With this commit, such a custom module can just create a new session on startup and then populate it. This takes a bit of fiddling to get the order of events correct, this commit also adds an example showing how to do this.

Note that the example added by this PR uses the `reload()` function introduced by #851, so best to merge that PR before this one.